### PR TITLE
Fix deprecation warning when showing error with rails 6.

### DIFF
--- a/lib/active_record/migrations/tasks.rb
+++ b/lib/active_record/migrations/tasks.rb
@@ -42,7 +42,7 @@ module ActiveRecord
 			module DatabaseTasks
 				def each_current_configuration(environment, spec_name = nil)
 					unless configuration = ActiveRecord::Base.configurations[environment]
-						raise ArgumentError.new("Cannot find configuration for environment #{environment.inspect} in #{ActiveRecord::Base.configurations.keys}")
+						raise ArgumentError.new("Cannot find configuration for environment #{environment.inspect} in #{ActiveRecord::Base.configurations.to_h.keys}")
 					end
 					
 					# This is a hack because DatabaseTasks functionality uses string for keys.

--- a/spec/active_record/migrations_spec.rb
+++ b/spec/active_record/migrations_spec.rb
@@ -53,4 +53,14 @@ RSpec.describe ActiveRecord::Migrations do
 			expect(File.read('db/schema.rb')).to include("version: 2016_12_08_121932")
 		end
 	end
+	
+	it "should handle non-existent configuration" do
+		require 'active_record/migrations/tasks'
+		ActiveRecord::Base.configurations = {
+			"development" => "null://test",
+		}
+		expect do
+			ActiveRecord::Tasks::DatabaseTasks.send(:each_current_configuration, "foo")
+		end.to raise_error(ArgumentError, 'Cannot find configuration for environment "foo" in ["development"]')
+	end
 end


### PR DESCRIPTION
This fixes the following error when using Rails 6:
> `ActiveRecord::Base.configurations` in Rails 6 now returns an object instead of a hash. The `keys` method is not supported. Please use `configs_for` or consult the documentation for supported methods.

Context:
```
/Users/michael/.rvm/gems/ruby-2.5.1/gems/activerecord-6.0.3.3/lib/active_record/database_configurations.rb:221:in `method_missing': `ActiveRecord::Base.configurations` in Rails 6 now returns an object instead of a hash. The `keys` method is not supported. Please use `configs_for` or consult the documentation for supported methods. (NotImplementedError)
  1: from /Users/michael/.rvm/gems/ruby-2.5.1/gems/activerecord-migrations-1.5.0/lib/active_record/migrations/tasks.rb:45:in `each_current_configuration'
  2: from /Users/michael/.rvm/gems/ruby-2.5.1/gems/activerecord-6.0.3.3/lib/active_record/tasks/database_tasks.rb:207:in `drop_current'
```

... which happens when `RAILS_ENV` and `DATABASE_VARIANT` disagree with each other.

Added a unit test to show a possible invocation.