### PR TITLE
Fix unused variable warning.

### DIFF
--- a/lib/active_record/migrations/tasks/db.rb
+++ b/lib/active_record/migrations/tasks/db.rb
@@ -70,8 +70,6 @@ namespace :db do
 	
 	desc 'Setup a new database if required and run migrations.'
 	task :deploy => [:load_config, :schema_path] do
-		database_tasks = ActiveRecord::Tasks::DatabaseTasks
-		
 		unless ActiveRecord::Migrations.database?
 			Rake::Task['db:create'].invoke
 			


### PR DESCRIPTION
Fixes the following error:
```
/Users/michael/Code/Socketry/activerecord-migrations/lib/active_record/migrations/tasks/db.rb:73: warning: assigned but unused variable - database_tasks
```